### PR TITLE
no-monitor added to acl

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -999,7 +999,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"acl",aclCommand,-2,
-     "admin no-script no-slowlog ok-loading ok-stale",
+     "admin no-script no-slowlog no-monitor ok-loading ok-stale",
      0,NULL,0,0,0,0,0,0}
 };
 


### PR DESCRIPTION
adding no-monitor to acl command. This will help prevent passwords from being monitored.